### PR TITLE
Use application-label field

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,14 +64,14 @@ exports.parse = function (filepath, callback) {
         });
 
         var applicationInfo = infosTemp['application'].split(' ');
-        var applicationLabel = null;
+        var applicationLabel = infosTemp['application-label'];
 
         applicationInfo.forEach(function (info) {
             if(info){
                 var t = info.split('=');
                 if(t.length === 2){
                     if(t[0].trim() == 'label'){
-                        applicationLabel = t[1].trim().replace('\'', '');
+                        applicationLabel = applicationLabel || t[1].trim().replace('\'', '');
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apker",
+  "name": "apker2",
   "version": "1.0.4",
   "description": "a node wraper for aapt(android)",
   "main": "index.js",
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/synder/apk-parser.git"
   },
-  "author": "SYNDE KEYES <812256717@qq.com>",
+  "author": "SYNDE KEYES <812256717@qq.com>, Taisuke HORI <taisuke.horix@gmail.com>",
   "keywords": [
     "aapt",
     "apk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apker2",
-  "version": "1.0.5",
+  "name": "apker",
+  "version": "1.0.4",
   "description": "a node wraper for aapt(android)",
   "main": "index.js",
   "bin": {
@@ -14,9 +14,9 @@
   },
   "repository":{
     "type": "git",
-    "url": "https://github.com/taisukeh/apk-parser.git"
+    "url": "https://github.com/synder/apk-parser.git"
   },
-  "author": "SYNDE KEYES <812256717@qq.com>, Taisuke HORI <taisuke.horix@gmail.com>",
+  "author": "author": "SYNDE KEYES <812256717@qq.com>",
   "keywords": [
     "aapt",
     "apk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apker2",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "a node wraper for aapt(android)",
   "main": "index.js",
   "bin": {
@@ -14,7 +14,7 @@
   },
   "repository":{
     "type": "git",
-    "url": "https://github.com/synder/apk-parser.git"
+    "url": "https://github.com/taisukeh/apk-parser.git"
   },
   "author": "SYNDE KEYES <812256717@qq.com>, Taisuke HORI <taisuke.horix@gmail.com>",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "https://github.com/synder/apk-parser.git"
   },
-  "author": "author": "SYNDE KEYES <812256717@qq.com>",
+  "author": "SYNDE KEYES <812256717@qq.com>",
   "keywords": [
     "aapt",
     "apk",


### PR DESCRIPTION
`infosTemp['application'].split(' ');` does not work correctly when the application contains a space. I changed the code to use `application-label'` if exists.